### PR TITLE
Add profile link in menu topbar

### DIFF
--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -83,6 +83,11 @@ header {
   color: #fff;
   font-weight: bold;
 }
+.nav-links a.profile {
+  background: #6c63ff;
+  color: #fff;
+  font-weight: bold;
+}
 .nav-links select {
   padding: 0.25rem;
   border: 1px solid #ddd;

--- a/public/js/menu/menu.js
+++ b/public/js/menu/menu.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const loginEl   = document.getElementById('login-link');
   const signupEl  = document.getElementById('signup-link');
   const dashEl    = document.getElementById('dashboard-link');
+  const profileEl = document.getElementById('profile-link');
   const logoutEl  = document.getElementById('logout-link');
 
   const container = document.getElementById('player-container');
@@ -88,6 +89,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     loginEl.style.display  = 'none';
     signupEl.style.display = 'none';
     dashEl.style.display   = 'inline-block';
+    profileEl.style.display= 'inline-block';
     logoutEl.style.display = 'inline-block';
     logoutEl.addEventListener('click', e => {
       e.preventDefault();
@@ -106,6 +108,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     loginEl.style.display  = '';
     signupEl.style.display = '';
     dashEl.style.display   = 'none';
+    profileEl.style.display= 'none';
     logoutEl.style.display = 'none';
   }
 

--- a/public/menu.html
+++ b/public/menu.html
@@ -28,6 +28,7 @@
       <a href="/index.html" id="login-link">login</a>
       <a href="/signup.html" class="sign-up" id="signup-link">sign up</a>
       <a href="/dashboard.html" class="dashboard btn" id="dashboard-link" style="display:none">dashboard</a>
+      <a href="/profile.html" class="profile btn" id="profile-link" style="display:none">profile</a>
       <a href="#" id="logout-link" style="display:none">logout</a>
       <select name="language" id="lang-select">
         <option value="fr">French</option>


### PR DESCRIPTION
## Summary
- add profile navigation link in menu
- show profile link only when logged in
- style new profile button similar to dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d508391f48328830b5704b043f096